### PR TITLE
Adding Gateway namespace to HTTPRoutes

### DIFF
--- a/eks-cross-cluster/lattice-service-network-policy.json
+++ b/eks-cross-cluster/lattice-service-network-policy.json
@@ -1,1 +1,11 @@
-{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"vpc-lattice-svcs:Invoke","Resource":"*"}]}
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "vpc-lattice-svcs:Invoke",
+            "Resource": "*"
+        }
+    ]
+}

--- a/eks-cross-cluster/lattice-service-policy.json
+++ b/eks-cross-cluster/lattice-service-policy.json
@@ -1,1 +1,18 @@
-{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::615847537300:role/aws-sigv4-client"},"Action":"vpc-lattice-svcs:Invoke","Resource":"arn:aws:vpc-lattice:us-west-2:615847537300:service/svc-0891088e6cc27c501/*","Condition":{"StringEquals":{"vpc-lattice-svcs:SourceVpc":"vpc-027baaaf7156c6075"}}}]}
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::615847537300:role/aws-sigv4-client"
+            },
+            "Action": "vpc-lattice-svcs:Invoke",
+            "Resource": "arn:aws:vpc-lattice:us-west-2:615847537300:service/svc-0891088e6cc27c501/*",
+            "Condition": {
+                "StringEquals": {
+                    "vpc-lattice-svcs:SourceVpc": "vpc-027baaaf7156c6075"
+                }
+            }
+        }
+    ]
+}

--- a/eks-cross-cluster/route-datastore-canary-custom-tls.yaml
+++ b/eks-cross-cluster/route-datastore-canary-custom-tls.yaml
@@ -10,6 +10,7 @@ spec:
   parentRefs:
   - name: eks-lattice-network
     sectionName: tls-with-custom-domain
+    namespace: default
   rules:  
   - backendRefs:  
     - name: datastore-v1-svc

--- a/eks-cross-cluster/route-datastore-canary-default-tls.yaml
+++ b/eks-cross-cluster/route-datastore-canary-default-tls.yaml
@@ -8,6 +8,7 @@ spec:
   parentRefs:
   - name: eks-lattice-network
     sectionName: tls-with-default-domain 
+    namespace: default
   rules:  
   - backendRefs:  
     - name: datastore-v1-svc

--- a/eks-cross-cluster/route-datastore-canary.yaml
+++ b/eks-cross-cluster/route-datastore-canary.yaml
@@ -10,6 +10,7 @@ spec:
   parentRefs:
   - name: eks-lattice-network
     sectionName: http 
+    namespace: default
   rules:  
   - backendRefs:  
     - name: datastore-v1-svc


### PR DESCRIPTION
*Description of changes:*
I was following the blog post and got to the step of deploying the HTTPRoute to the cluster in VPC B to create the Lattice Service and Target groups. Turns out it doesn't work unless you specify the namespace of the Gateway.

I also formatted the IAM policies to make them easier to read.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
